### PR TITLE
Add budgeting web app with chart visualization

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,338 @@
+const STORAGE_KEY = "budget-transactions";
+
+const form = document.getElementById("transaction-form");
+const tableBody = document.getElementById("transaction-table");
+const template = document.getElementById("transaction-row-template");
+const totalIncomeEl = document.getElementById("total-income");
+const totalExpenseEl = document.getElementById("total-expense");
+const balanceEl = document.getElementById("balance");
+const chartRangeSelect = document.getElementById("chart-range");
+const clearBtn = document.getElementById("clear-transactions");
+const dateInput = document.getElementById("date");
+const chartEmptyMessage = document.getElementById("chart-empty");
+
+let chartInstance;
+
+const state = {
+  transactions: loadTransactions(),
+};
+
+init();
+
+function init() {
+  setDefaultDate();
+  render();
+  form.addEventListener("submit", onSubmit);
+  tableBody.addEventListener("click", onTableClick);
+  chartRangeSelect.addEventListener("change", updateChart);
+  clearBtn.addEventListener("click", onClearAll);
+}
+
+function onSubmit(event) {
+  event.preventDefault();
+  const formData = new FormData(form);
+
+  const transaction = {
+    id: generateId(),
+    type: formData.get("type"),
+    category: formData.get("category").trim(),
+    amount: Number(formData.get("amount")),
+    date: formData.get("date"),
+    note: formData.get("note").trim(),
+  };
+
+  if (!transaction.category || !transaction.date || transaction.amount <= 0) {
+    alert("請確認所有欄位皆已填寫且金額大於 0。");
+    return;
+  }
+
+  state.transactions.push(transaction);
+  persistTransactions();
+  form.reset();
+  setDefaultDate();
+  render();
+}
+
+function onTableClick(event) {
+  const button = event.target.closest("button[data-action='delete']");
+  if (!button) return;
+
+  const row = button.closest("tr");
+  const id = row?.dataset?.id;
+  if (!id) return;
+
+  state.transactions = state.transactions.filter((item) => item.id !== id);
+  persistTransactions();
+  render();
+}
+
+function onClearAll() {
+  if (state.transactions.length === 0) return;
+  const confirmed = confirm("確定要清空所有交易紀錄嗎？此動作無法復原。");
+  if (!confirmed) return;
+
+  state.transactions = [];
+  persistTransactions();
+  render();
+}
+
+function render() {
+  renderSummary();
+  renderTable();
+  updateClearButton();
+  updateChart();
+}
+
+function renderSummary() {
+  const totals = state.transactions.reduce(
+    (acc, transaction) => {
+      if (transaction.type === "income") {
+        acc.income += transaction.amount;
+      } else {
+        acc.expense += transaction.amount;
+      }
+      return acc;
+    },
+    { income: 0, expense: 0 }
+  );
+
+  const balance = totals.income - totals.expense;
+
+  totalIncomeEl.textContent = formatCurrency(totals.income);
+  totalExpenseEl.textContent = formatCurrency(totals.expense);
+  balanceEl.textContent = formatCurrency(balance);
+  balanceEl.classList.toggle("negative", balance < 0);
+}
+
+function renderTable() {
+  tableBody.innerHTML = "";
+
+  const sorted = [...state.transactions].sort((a, b) =>
+    new Date(b.date) - new Date(a.date)
+  );
+
+  for (const transaction of sorted) {
+    const clone = template.content.firstElementChild.cloneNode(true);
+    clone.dataset.id = transaction.id;
+
+    clone.querySelector('[data-field="date"]').textContent = formatDate(
+      transaction.date
+    );
+    clone.querySelector('[data-field="category"]').textContent =
+      transaction.category || "-";
+    clone.querySelector('[data-field="type"]').textContent =
+      transaction.type === "income" ? "收入" : "支出";
+    clone.querySelector('[data-field="amount"]').textContent =
+      (transaction.type === "expense" ? "-" : "") +
+      formatCurrency(transaction.amount, false);
+    clone.querySelector('[data-field="note"]').textContent =
+      transaction.note || "-";
+
+    tableBody.appendChild(clone);
+  }
+
+  if (state.transactions.length === 0) {
+    const emptyRow = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = 6;
+    cell.textContent = "目前尚無交易紀錄，快來新增第一筆吧！";
+    cell.style.textAlign = "center";
+    cell.style.padding = "1.5rem";
+    cell.style.color = "var(--muted)";
+    emptyRow.appendChild(cell);
+    tableBody.appendChild(emptyRow);
+  }
+}
+
+function updateChart() {
+  const range = chartRangeSelect.value;
+  const filtered = getFilteredTransactions(range);
+  const sorted = filtered.sort((a, b) => new Date(a.date) - new Date(b.date));
+
+  const labels = [];
+  const balances = [];
+  let runningBalance = 0;
+
+  for (const transaction of sorted) {
+    runningBalance +=
+      transaction.type === "income"
+        ? transaction.amount
+        : -transaction.amount;
+    labels.push(formatDate(transaction.date));
+    balances.push(Number(runningBalance.toFixed(2)));
+  }
+
+  chartEmptyMessage.hidden = balances.length !== 0;
+
+  const bounds = getChartBounds(balances);
+
+  if (!chartInstance) {
+    const ctx = document.getElementById("balance-chart").getContext("2d");
+    chartInstance = new Chart(ctx, {
+      type: "line",
+      data: {
+        labels,
+        datasets: [
+          {
+            label: "結餘",
+            data: balances,
+            fill: true,
+            borderColor: "#5d5fe7",
+            backgroundColor: "rgba(93, 95, 231, 0.15)",
+            tension: 0.3,
+            pointRadius: 4,
+            pointHoverRadius: 6,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        plugins: {
+          legend: {
+            display: false,
+          },
+          tooltip: {
+            callbacks: {
+              label: (context) => `結餘：${formatCurrency(context.parsed.y)}`,
+            },
+          },
+        },
+        scales: {
+          x: {
+            ticks: {
+              maxTicksLimit: 6,
+            },
+          },
+          y: {
+            beginAtZero: false,
+            suggestedMin: bounds.min,
+            suggestedMax: bounds.max,
+            ticks: {
+              callback: (value) => formatCurrency(value),
+            },
+          },
+        },
+      },
+    });
+  } else {
+    chartInstance.data.labels = labels;
+    chartInstance.data.datasets[0].data = balances;
+    chartInstance.options.scales.y.suggestedMin = bounds.min;
+    chartInstance.options.scales.y.suggestedMax = bounds.max;
+    chartInstance.update();
+  }
+}
+
+function getFilteredTransactions(range) {
+  if (range === "all") {
+    return [...state.transactions];
+  }
+
+  const now = new Date();
+  const startDate = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+  const monthsMap = {
+    "3m": 3,
+    "6m": 6,
+    "12m": 12,
+  };
+
+  const months = monthsMap[range] ?? 0;
+  startDate.setMonth(startDate.getMonth() - months);
+
+  return state.transactions.filter((transaction) => {
+    const transactionDate = new Date(transaction.date);
+    return transactionDate >= startDate;
+  });
+}
+
+function persistTransactions() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state.transactions));
+}
+
+function loadTransactions() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (item) =>
+        item &&
+        typeof item === "object" &&
+        item.id &&
+        item.date &&
+        (item.type === "income" || item.type === "expense") &&
+        typeof item.amount === "number" &&
+        !Number.isNaN(item.amount)
+    );
+  } catch (error) {
+    console.error("Failed to load transactions", error);
+    return [];
+  }
+}
+
+function setDefaultDate() {
+  const today = new Date();
+  const formatted = today.toISOString().split("T")[0];
+  dateInput.value = formatted;
+}
+
+function formatCurrency(value, withSymbol = true) {
+  const options = {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  };
+
+  if (withSymbol) {
+    options.style = "currency";
+    options.currency = "TWD";
+  }
+
+  const formatter = new Intl.NumberFormat("zh-Hant", options);
+  return formatter.format(Number(value) || 0);
+}
+
+function formatDate(value) {
+  if (!value) return "";
+  return new Date(value).toLocaleDateString("zh-Hant", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+}
+
+window.addEventListener("storage", () => {
+  state.transactions = loadTransactions();
+  render();
+});
+
+function updateClearButton() {
+  const disabled = state.transactions.length === 0;
+  clearBtn.disabled = disabled;
+}
+
+function generateId() {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 9)}`;
+}
+
+function getChartBounds(values) {
+  if (!values.length) {
+    return { min: 0, max: 100 };
+  }
+
+  const minValue = Math.min(...values, 0);
+  const maxValue = Math.max(...values, 0);
+  const span = maxValue - minValue;
+  const padding = span === 0 ? Math.max(Math.abs(maxValue), 50) * 0.2 : span * 0.15;
+
+  return {
+    min: minValue - padding,
+    max: maxValue + padding,
+  };
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>記帳小幫手</title>
+    <link rel="stylesheet" href="style.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>記帳小幫手</h1>
+      <p>用圖表掌握收支變化，讓理財更有感！</p>
+    </header>
+
+    <main class="layout">
+      <section class="card form-card">
+        <h2>新增交易</h2>
+        <form id="transaction-form">
+          <div class="form-group">
+            <label for="type">類型</label>
+            <select id="type" name="type" required>
+              <option value="income">收入</option>
+              <option value="expense">支出</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label for="category">分類</label>
+            <input
+              id="category"
+              name="category"
+              type="text"
+              placeholder="例如：薪水、餐飲"
+              required
+            />
+          </div>
+          <div class="form-group">
+            <label for="amount">金額</label>
+            <input
+              id="amount"
+              name="amount"
+              type="number"
+              min="0"
+              step="0.01"
+              required
+            />
+          </div>
+          <div class="form-group">
+            <label for="date">日期</label>
+            <input id="date" name="date" type="date" required />
+          </div>
+          <div class="form-group">
+            <label for="note">備註</label>
+            <input id="note" name="note" type="text" placeholder="可留空" />
+          </div>
+          <button type="submit" class="btn primary">加入</button>
+        </form>
+      </section>
+
+      <section class="card summary-card">
+        <h2>收支摘要</h2>
+        <div class="summary">
+          <div>
+            <span class="summary-label">總收入</span>
+            <span class="summary-value income" id="total-income">$0</span>
+          </div>
+          <div>
+            <span class="summary-label">總支出</span>
+            <span class="summary-value expense" id="total-expense">$0</span>
+          </div>
+          <div>
+            <span class="summary-label">結餘</span>
+            <span class="summary-value balance" id="balance">$0</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="card chart-card">
+        <div class="chart-header">
+          <h2>結餘走勢</h2>
+          <select id="chart-range">
+            <option value="all">全部</option>
+            <option value="3m">近三個月</option>
+            <option value="6m">近半年</option>
+            <option value="12m">近一年</option>
+          </select>
+        </div>
+        <canvas id="balance-chart" height="200"></canvas>
+        <p id="chart-empty" class="chart-empty" hidden>
+          暫無資料，請新增交易或調整範圍。
+        </p>
+      </section>
+
+      <section class="card table-card">
+        <div class="table-header">
+          <h2>交易記錄</h2>
+          <button id="clear-transactions" class="btn danger" type="button">
+            清空全部
+          </button>
+        </div>
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>日期</th>
+                <th>分類</th>
+                <th>類型</th>
+                <th class="align-right">金額</th>
+                <th>備註</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody id="transaction-table"></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <footer class="app-footer">
+      <p>資料將保存在瀏覽器的 LocalStorage，請放心使用。</p>
+    </footer>
+
+    <template id="transaction-row-template">
+      <tr>
+        <td data-field="date"></td>
+        <td data-field="category"></td>
+        <td data-field="type"></td>
+        <td data-field="amount" class="align-right"></td>
+        <td data-field="note"></td>
+        <td class="action-cell">
+          <button class="btn ghost" data-action="delete">刪除</button>
+        </td>
+      </tr>
+    </template>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,258 @@
+:root {
+  --bg: #f6f8fb;
+  --card-bg: #ffffff;
+  --primary: #5d5fe7;
+  --primary-dark: #4c4fce;
+  --danger: #f25f5c;
+  --text: #1f2933;
+  --muted: #7b8794;
+  --border: #e4e7eb;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-family: "Noto Sans TC", system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  background: linear-gradient(135deg, #6c6efb, #5d5fe7);
+  color: #ffffff;
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  box-shadow: 0 6px 24px rgba(93, 95, 231, 0.2);
+}
+
+.app-header h1 {
+  font-size: 2.4rem;
+  margin-bottom: 0.5rem;
+}
+
+.app-header p {
+  font-size: 1.1rem;
+  opacity: 0.85;
+}
+
+.layout {
+  width: min(1100px, 92vw);
+  margin: -3.5rem auto 2rem;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: start;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+}
+
+.card h2 {
+  font-size: 1.3rem;
+  margin-bottom: 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+  gap: 0.35rem;
+}
+
+label {
+  font-weight: 500;
+}
+
+input,
+select {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.65rem 0.75rem;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 4px rgba(93, 95, 231, 0.12);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.55rem 1.4rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.btn:active {
+  transform: translateY(1px);
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(93, 95, 231, 0.28);
+}
+
+.btn.primary:hover {
+  box-shadow: 0 16px 28px rgba(93, 95, 231, 0.35);
+}
+
+.btn.danger {
+  background: var(--danger);
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(242, 95, 92, 0.25);
+}
+
+.btn.danger:hover {
+  box-shadow: 0 16px 28px rgba(242, 95, 92, 0.35);
+}
+
+.btn.ghost {
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  padding: 0.4rem 1rem;
+}
+
+.btn.ghost:hover {
+  color: var(--text);
+  border-color: var(--primary);
+}
+
+.summary {
+  display: grid;
+  gap: 1rem;
+}
+
+.summary-label {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.summary-value {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.summary-value.income {
+  color: #2eb872;
+}
+
+.summary-value.expense {
+  color: #ef4444;
+}
+
+.summary-value.balance {
+  color: var(--primary-dark);
+}
+
+.summary-value.balance.negative {
+  color: #ef4444;
+}
+
+.chart-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.chart-header select {
+  min-width: 140px;
+}
+
+.chart-empty {
+  margin-top: 1rem;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.table-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: #f9fafb;
+}
+
+thead th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--muted);
+  font-size: 0.85rem;
+  padding: 0.75rem 0.5rem;
+}
+
+tbody td {
+  padding: 0.85rem 0.5rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.95rem;
+}
+
+.align-right {
+  text-align: right;
+}
+
+.action-cell {
+  text-align: right;
+}
+
+.app-footer {
+  margin-top: auto;
+  text-align: center;
+  padding: 1.5rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+  .layout {
+    grid-template-columns: 1fr;
+    margin-top: -2.5rem;
+  }
+
+  .card {
+    padding: 1.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a budgeting dashboard layout with forms, summary cards, and a balance chart canvas
- style the interface with modern theming, responsive layout, and button states
- implement transaction management, localStorage persistence, and Chart.js balance visualization

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dc11561554832f927b3be14d9c3f08